### PR TITLE
Add DB clean up BG service, update item service get, post, put

### DIFF
--- a/src/Application/Application.csproj
+++ b/src/Application/Application.csproj
@@ -12,6 +12,7 @@
     <PackageReference Include="Serilog" Version="3.1.1" />
     <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
     <PackageReference Include="System.Security.Cryptography.Algorithms" Version="4.3.1" />
+	<PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="6.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Application/Services/ItemService.cs
+++ b/src/Application/Services/ItemService.cs
@@ -53,15 +53,17 @@ public class ItemService
 
         DateTime updatedDate = DateTime.UtcNow.AddSeconds(itemEntity.ExpirationPeriod);
 
+        itemEntity.ExpirationDate = updatedDate;
+
+        await _itemRepository.UpdateExDate(itemEntity);
+
         Item item = new()
         {
             Key = itemEntity.Key,
             Value = JsonSerializer.Deserialize<List<object>>(itemEntity.Value),
             ExpirationPeriod = itemEntity.ExpirationPeriod,
-            ExpirationDate = updatedDate
+            ExpirationDate = itemEntity.ExpirationDate
         };
-
-        await _itemRepository.UpdateExDate(itemEntity.Key, updatedDate);
 
         return item;
     }
@@ -75,7 +77,6 @@ public class ItemService
 
         if (exPeriod > _maxItemExPeriod)
             throw new ArgumentException($"Invalid ExpirationPeriod field");
-
 
         if (await _itemRepository.Get(itemDto.Key) is null)
         {

--- a/src/Domain/Interfaces/IItemRepository.cs
+++ b/src/Domain/Interfaces/IItemRepository.cs
@@ -10,5 +10,5 @@ public interface IItemRepository
     public Task<ItemEntity?> Update(ItemEntity itemEntity);
     public Task Delete(string key);
     public Task<int> DeleteExpiredItems(DateTime date);
-    public Task UpdateExDate(string key, DateTime date);
+    public Task UpdateExDate(ItemEntity itemEntity);
 }

--- a/src/Domain/Interfaces/IItemRepository.cs
+++ b/src/Domain/Interfaces/IItemRepository.cs
@@ -9,4 +9,6 @@ public interface IItemRepository
     public Task<ItemEntity?> Create(ItemEntity itemEntity);
     public Task<ItemEntity?> Update(ItemEntity itemEntity);
     public Task Delete(string key);
+    public Task<int> DeleteExpiredItems(DateTime date);
+    public Task UpdateExDate(string key, DateTime date);
 }

--- a/src/Infrastructure/DependencyInjection.cs
+++ b/src/Infrastructure/DependencyInjection.cs
@@ -1,5 +1,6 @@
 ﻿using Domain.Interfaces;
 using Infrastructure.Repository;
+using Infrastructure.Services;
 using Microsoft.Extensions.DependencyInjection;
 using Npgsql;
 using System.Data;
@@ -14,5 +15,6 @@ public static class DependencyInjection
         services.AddScoped<IDbConnection>(sp => new NpgsqlConnection(dbConnectionString));
         services.AddScoped<IItemRepository, ItemRepository>();
         services.AddScoped<IUserRepository, UserRepository>();
+        services.AddHostedService<DbCleanupBgService>();
     }
 }

--- a/src/Infrastructure/Repository/ItemRepository.cs
+++ b/src/Infrastructure/Repository/ItemRepository.cs
@@ -43,7 +43,7 @@ public class ItemRepository : IItemRepository
     public async Task<ItemEntity?> Update(ItemEntity itemEntity)
     {
         string sql = @"UPDATE items 
-                        SET key=@Key, value=@Value, expiration_period=@ExpirationPeriod
+                        SET key=@Key, value=@Value, expiration_period=@ExpirationPeriod, expiration_date=@ExpirationDate
                         WHERE key=@Key 
                         RETURNING *";
 
@@ -56,5 +56,20 @@ public class ItemRepository : IItemRepository
                         WHERE key=@Key";
 
         await _dbConnection.ExecuteAsync(sql, new { key });
+    }
+
+    public async Task<int> DeleteExpiredItems(DateTime date)
+    {
+        var sql = @"DELETE FROM Items
+                     WHERE expiration_date <= @ExpiredDate";
+
+        return await _dbConnection.ExecuteAsync(sql, new { ExpiredDate = date });
+    }
+
+    public async Task UpdateExDate(string key, DateTime date)
+    {
+        string sql = "UPDATE items SET expiration_date = @ExpirationDate WHERE key = @Key";
+
+        await _dbConnection.ExecuteAsync(sql, new { ExpirationDate = date, Key = key });
     }
 }

--- a/src/Infrastructure/Repository/ItemRepository.cs
+++ b/src/Infrastructure/Repository/ItemRepository.cs
@@ -69,7 +69,8 @@ public class ItemRepository : IItemRepository
     public async Task UpdateExDate(ItemEntity itemEntity)
     {
         string sql = @"UPDATE items 
-                        SET expiration_date = @ExpirationDate WHERE key = @Key";
+                        SET expiration_date = @ExpirationDate
+                        WHERE key = @Key";
 
         await _dbConnection.ExecuteAsync(sql, new { ExpirationDate = itemEntity.ExpirationDate, Key = itemEntity.Key });
     }

--- a/src/Infrastructure/Repository/ItemRepository.cs
+++ b/src/Infrastructure/Repository/ItemRepository.cs
@@ -60,16 +60,17 @@ public class ItemRepository : IItemRepository
 
     public async Task<int> DeleteExpiredItems(DateTime date)
     {
-        var sql = @"DELETE FROM Items
-                     WHERE expiration_date <= @ExpiredDate";
+        string sql = @"DELETE FROM Items
+                        WHERE expiration_date <= @ExpiredDate";
 
         return await _dbConnection.ExecuteAsync(sql, new { ExpiredDate = date });
     }
 
-    public async Task UpdateExDate(string key, DateTime date)
+    public async Task UpdateExDate(ItemEntity itemEntity)
     {
-        string sql = "UPDATE items SET expiration_date = @ExpirationDate WHERE key = @Key";
+        string sql = @"UPDATE items 
+                        SET expiration_date = @ExpirationDate WHERE key = @Key";
 
-        await _dbConnection.ExecuteAsync(sql, new { ExpirationDate = date, Key = key });
+        await _dbConnection.ExecuteAsync(sql, new { ExpirationDate = itemEntity.ExpirationDate, Key = itemEntity.Key });
     }
 }

--- a/src/Infrastructure/Services/DbCleanupBgService.cs
+++ b/src/Infrastructure/Services/DbCleanupBgService.cs
@@ -29,7 +29,7 @@ public class DbCleanupBgService : BackgroundService
             {
                 using (var scope = _scopeFactory.CreateScope())
                 {
-                    var itemRepository = scope.ServiceProvider.GetRequiredService<IItemRepository>();
+                    IItemRepository itemRepository = scope.ServiceProvider.GetRequiredService<IItemRepository>();
 
                     DateTime date = DateTime.UtcNow;
 

--- a/src/Infrastructure/Services/DbCleanupBgService.cs
+++ b/src/Infrastructure/Services/DbCleanupBgService.cs
@@ -1,0 +1,47 @@
+﻿using Domain.Interfaces;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace Infrastructure.Services;
+public class DbCleanupBgService : BackgroundService
+{
+    private readonly IConfiguration _configuration;
+    private readonly ILogger<DbCleanupBgService> _logger;
+    private readonly IServiceScopeFactory _scopeFactory;
+
+    public DbCleanupBgService(IConfiguration configuration, ILogger<DbCleanupBgService> logger, IServiceScopeFactory scopeFactory)
+    {
+        _configuration = configuration;
+        _logger = logger;
+        _scopeFactory = scopeFactory;
+    }
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            try
+            {
+                using (var scope = _scopeFactory.CreateScope())
+                {
+                    var itemRepository = scope.ServiceProvider.GetRequiredService<IItemRepository>();
+
+                    DateTime date = DateTime.UtcNow;
+
+                    int rowsDeleted = await itemRepository.DeleteExpiredItems(date);
+
+                    _logger.LogInformation("Database cleanup completed successfully. {RowsDeleted} rows deleted.", rowsDeleted);
+                }
+
+                var dbCleanupInterval = _configuration.GetValue<int>("DbCleanupInterval");
+
+                await Task.Delay(TimeSpan.FromSeconds(dbCleanupInterval), stoppingToken);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error occurred during database cleanup.");
+            }
+        }
+    }
+}

--- a/src/Infrastructure/Services/DbCleanupBgService.cs
+++ b/src/Infrastructure/Services/DbCleanupBgService.cs
@@ -18,7 +18,6 @@ public class DbCleanupBgService : BackgroundService
         _logger = logger;
         _scopeFactory = scopeFactory;
         _dbCleanupInterval = _configuration.GetValue<int>("DbCleanupInterval");
-
     }
 
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
@@ -42,9 +41,8 @@ public class DbCleanupBgService : BackgroundService
             {
                 _logger.LogError(ex, "Error occurred during database cleanup.");
             }
+
             await Task.Delay(TimeSpan.FromSeconds(_dbCleanupInterval), stoppingToken);
-
         }
-
     }
 }

--- a/src/WebAPI/appsettings.json
+++ b/src/WebAPI/appsettings.json
@@ -6,6 +6,8 @@
     }
   },
   "ItemExpirationPeriod": 3600,
+  "MaxItemExpirationPeriod": 7200,
+  "DbCleanupInterval": 10,
   "JWT": {
     "SecretKey": "MonkeySeeMonkeyDoWhatEverYouWhant",
     "Issuer": "ATeam",


### PR DESCRIPTION
Each time after 'get' is used for a particular key, the expiration period for that key should reset (meaning that only unused values are expiring)
dictionary should have it's internal cleanup mechanism to get rid of "zombie" records and maintain health memory usage by cleaning up the trash. Cleanup interval and max expiration period should be defined in config. User should not be allowed to create records with expiration period longer that the max defined in config.